### PR TITLE
correct `calc_rational_iv` inputs with rate and dividend

### DIFF
--- a/src/implied_volatility.rs
+++ b/src/implied_volatility.rs
@@ -93,15 +93,10 @@ impl ImpliedVolatility<f32> for Inputs {
     }
 
     /// Calculates the implied volatility of the option.
-    /// Tolerance is the max error allowed for the implied volatility,
-    /// the lower the tolerance the more iterations will be required.
-    /// Recommended to be a value between 0.001 - 0.0001 for highest efficiency/accuracy.
-    /// Initializes estimation of sigma using Brenn and Subrahmanyam (1998) method of calculating initial iv estimation.
-    /// Uses Newton Raphson algorithm to calculate implied volatility.
     /// # Requires
     /// s, k, r, t, p
     /// # Returns
-    /// f32 of the implied volatility of the option.
+    /// f64 of the implied volatility of the option.
     /// # Example:
     /// ```
     /// use blackscholes::{Inputs, OptionType, ImpliedVolatility};
@@ -113,18 +108,29 @@ impl ImpliedVolatility<f32> for Inputs {
     /// from Jackel's C++ implementation, imported through the C FFI.  The C++ implementation is available at [here](http://www.jaeckel.org/LetsBeRational.7z)
     /// Per Jackel's whitepaper, this method can solve for the implied volatility to f64 precision in 2 iterations.
     fn calc_rational_iv(&self) -> Result<f64, String> {
-        let p: c_double = match self.p {
-            Some(p) => p.into(),
-            None => return Err("Option price is required".to_string()),
-        };
-        let s: c_double = self.s.into();
+        // extract price, or return error
+        let p = self.p.ok_or("Option price is required".to_string())?;
+
+        // "let's be rational" works with the forward and undiscounted option price, so remove the discount
+        let rate_inv_discount = (self.r * self.t).exp();
+        let p = p * rate_inv_discount;
+
+        // compute the forward price
+        let f = self.s * rate_inv_discount;
+        // The Black-Scholes-Merton formula takes into account dividend yield by setting S = S * e^{-qt}, do this here with the forward
+        let f = f * (- self.q * self.t).exp();
+        
+        // now convert into c_double for ffi
+        let p: c_double = p.into();
+        let f: c_double = f.into();
         let k: c_double = self.k.into();
         let t: c_double = self.t.into();
         let q: c_double = match self.option_type {
             OptionType::Call => 1.0,
             OptionType::Put => -1.0,
         };
-        let sigma = unsafe { implied_volatility_from_a_transformed_rational_guess(p, s, k, t, q) };
+
+        let sigma = unsafe { implied_volatility_from_a_transformed_rational_guess(p, f, k, t, q) };
 
         if sigma.is_nan() || sigma.is_infinite() || sigma < 0.0 {
             Err("Implied volatility failed to converge".to_string())?


### PR DESCRIPTION
after perusing the formulas in section 1 and 2 of the "Let's be rational" paper, it seems the formulas would use the undiscounted price (first paragraph of Section 1), and would use the forward price (formula 2.1 and variable naming in code).

Also took into account the continuous dividend `q`.

With these changes, `calc_rational_iv` now gives comparable results to the `black_scholes` crate for me.


Thank you to the contributors for the work you put in this crate! Loved that "let's be rational" is available in Rust! 🙏 