### PR TITLE
add support for pricing via "let's be rational"

### DIFF
--- a/src/lets_be_rational.rs
+++ b/src/lets_be_rational.rs
@@ -1,0 +1,49 @@
+use libc::c_double;
+
+#[link(name = "liblets_be_rational")]
+extern "C" {
+    // rename the ffi functions with `_ffi` so the wrapper functions with native types can have the name from the library
+
+    #[link_name = "implied_volatility_from_a_transformed_rational_guess"]
+    fn implied_volatility_from_a_transformed_rational_guess_ffi(
+        price: c_double,
+        F: c_double,
+        K: c_double,
+        T: c_double,
+        q: c_double,
+    ) -> c_double;
+
+    #[link_name = "black"]
+    //  double K, double sigma, double T, double q /* q=±1 */) -> c_double
+    fn black_ffi(
+        F: c_double,
+        K: c_double,
+        sigma: c_double,
+        T: c_double,
+        q: c_double,
+    ) -> c_double;
+}
+
+pub fn implied_volatility_from_a_transformed_rational_guess(
+    price: f64,
+    f: f64,
+    k: f64,
+    t: f64,
+    q: f64,
+) -> f64 {
+    let price: c_double = price.into();
+    let f: c_double = f.into();
+    let k: c_double = k.into();
+    let t: c_double = t.into();
+    let q: c_double = q.into();
+    unsafe { implied_volatility_from_a_transformed_rational_guess_ffi(price, f, k, t, q) }
+}
+
+pub fn black(f: f64, k: f64, sigma: f64, t: f64, q: f64) -> f64 {
+    let f: c_double = f.into();
+    let k: c_double = k.into();
+    let sigma: c_double = sigma.into();
+    let t: c_double = t.into();
+    let q: c_double = q.into();
+    unsafe { black_ffi(f, k, sigma, t, q) }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod greeks;
 mod implied_volatility;
 mod inputs;
 mod pricing;
+mod lets_be_rational;
 
 pub use greeks::Greeks;
 pub use implied_volatility::ImpliedVolatility;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod greeks;
 mod implied_volatility;
 mod inputs;
 mod pricing;
-mod lets_be_rational;
+pub mod lets_be_rational;
 
 pub use greeks::Greeks;
 pub use implied_volatility::ImpliedVolatility;

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -1,10 +1,11 @@
-use crate::{common::*, constants::*, Inputs, OptionType};
+use crate::{common::*, constants::*, Inputs, OptionType, lets_be_rational};
 use num_traits::Float;
 pub trait Pricing<T>
 where
     T: Float,
 {
     fn calc_price(&self) -> Result<T, String>;
+    fn calc_rational_price(&self) -> Result<f64, String>;
 }
 
 impl Pricing<f32> for Inputs {
@@ -34,4 +35,44 @@ impl Pricing<f32> for Inputs {
         };
         Ok(price)
     }
+
+    /// Calculates the price of the option using the "Let's Be Rational" implementation.
+    /// # Requires
+    /// s, k, r, q, t, sigma.
+    /// # Returns
+    /// f64 of the price of the option.
+    /// # Example
+    /// ```
+    /// use blackscholes::{Inputs, OptionType, Pricing};
+    /// let inputs = Inputs::new(OptionType::Call, 100.0, 100.0, None, 0.05, 0.2, 20.0/365.25, Some(0.2));
+    /// let price = inputs.calc_rational_price().unwrap();
+    /// ```
+    fn calc_rational_price(&self) -> Result<f64, String> {
+        let sigma = self
+            .sigma
+            .ok_or("Expected Some(f32) for self.sigma, received None")?;
+        
+        // let's be rational wants the forward price, not the spot price.
+        let forward = self.s * ((self.r - self.q) * self.t).exp();
+
+        // convert the option type into \theta
+        let q: f64 = match self.option_type {
+            OptionType::Call => 1.0,
+            OptionType::Put => -1.0,
+        };
+
+        // price using `black`
+        let undiscounted_price = lets_be_rational::black(
+            forward as f64,
+            self.k as f64,
+            sigma as f64,
+            self.t as f64,
+            q,
+        );
+
+        // discount the price
+        let price = undiscounted_price * (-self.r as f64 * self.t as f64).exp();
+        Ok(price)
+    }
+
 }

--- a/tests/bstest.rs
+++ b/tests/bstest.rs
@@ -1,4 +1,4 @@
-use blackscholes::{Greeks, ImpliedVolatility, Pricing};
+use blackscholes::Pricing;
 
 const INPUTS_CALL_OTM: blackscholes::Inputs = blackscholes::Inputs {
     option_type: blackscholes::OptionType::Call,
@@ -57,4 +57,28 @@ fn price_put_otm() {
 #[test]
 fn price_put_itm() {
     assert!((INPUTS_PUT_ITM.calc_price().unwrap() - 10.0103).abs() < 0.001);
+}
+#[test]
+fn price_using_lets_be_rational() {
+    // compare the results from calc_price() and calc_rational_price() for the options above
+    assert!(
+        (INPUTS_CALL_OTM.calc_price().unwrap() - INPUTS_CALL_OTM.calc_rational_price().unwrap() as f32)
+            .abs()
+            < 0.001
+    );
+    assert!(
+        (INPUTS_CALL_ITM.calc_price().unwrap() - INPUTS_CALL_ITM.calc_rational_price().unwrap() as f32)
+            .abs()
+            < 0.001
+    );
+    assert!(
+        (INPUTS_PUT_OTM.calc_price().unwrap() - INPUTS_PUT_OTM.calc_rational_price().unwrap() as f32)
+            .abs()
+            < 0.001
+    );
+    assert!(
+        (INPUTS_PUT_ITM.calc_price().unwrap() - INPUTS_PUT_ITM.calc_rational_price().unwrap() as f32)
+            .abs()
+            < 0.001
+    );
 }


### PR DESCRIPTION
the "let's be rational" paper claims to have put significant effort into stabilizing pricing (not only computing implied volatility): 

> As was perhaps previously underestimated, of crucial importance for the precision of the implied volatility is a highly accurate Black function that minimizes round- off errors and numerical truncations in the various para- meter limits. We implement the Black call option price by the aid of Cody’s [Cod69, Cod90] rational approxim- ation for the complementary error function erfc(·) and its little known cousin, the scaled complementary error func- tion erfcx(·).

(from the paper's abstract)

This PR adds FFI for let's be rational's `black()` function (also moving both wrappers into a module), and adds `calc_rational_price()` to the Pricing trait (similar naming convention as `calc_iv()` / `calc_rational_iv()`.

A new test (which passes for me) compares the output of `calc_rational_price()` to `calc_price()`.

