### PR TITLE
Add GitHub Actions Workflow for Publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish process for blacksholes-rust
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy'
+        required: true
+        default: '0.0.0'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check version
+        run: |
+          CURRENT_VERSION=$(sed -n -e 's/^version = "\(.*\)"/\1/p' Cargo.toml)
+          INPUT_VERSION=${{ github.event.inputs.version }}
+          if [[ ! $INPUT_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Input version is not in the correct format (0-9.0-9.0-9)"
+            exit 1
+          fi
+          if [[ $(printf '%s\n' "$INPUT_VERSION" "$CURRENT_VERSION" | sort --version-sort | head -n1) == "$INPUT_VERSION" ]]; then
+            echo "Input version is not greater than the current version"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Update version in toml
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/version/}
+          sed -i "s/^version = .*/version = \"${{ github.event.inputs.version }}\"/" Cargo.toml
+      - name: Commit and tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -am "Bump version to ${{ github.event.inputs.version }}"
+          git push origin main
+          git tag version/${{ github.event.inputs.version }}
+          git push origin --tags
+
+      - name: Login to crates.io
+        run: echo "${{ secrets.CARGO_TOKEN }}" | cargo login
+      - name: Publish
+        run: cargo publish --verbose


### PR DESCRIPTION
**Context**
This PR introduces a new GitHub Actions workflow named `publish.yml`, designed to automate the process of publishing our Rust package to crates.io. The workflow is triggered manually through the GitHub Actions UI, allowing maintainers to specify the version to be deployed directly.
Based on issue #2 

**Changes**
- **Version Validation**: Ensures the specified version follows the semantic versioning format (MAJOR.MINOR.PATCH) and is greater than the current version in `Cargo.toml`.
- **Version Bumping**: Automatically updates the version in `Cargo.toml` to match the specified version.
- **Committing and Tagging**: Commits the updated `Cargo.toml` and creates a git tag for the new version.
- **Publishing**: Logs into `crates.io` using a secret token and publishes the new version.

**Requirements**
- adding secret `CARGO_TOKEN` as crates.io token with possibility to push new versions 
![image](https://github.com/hayden4r4/blackscholes-rust/assets/9306654/9a241e12-6da1-4aa4-9a0d-cfa9d8a94b67)
- changing rights for GH-Runner to commit and push changes
 
![image](https://github.com/hayden4r4/blackscholes-rust/assets/9306654/8b34e01d-4ed7-4a8d-846d-21ed02ddb147)
![image](https://github.com/hayden4r4/blackscholes-rust/assets/9306654/f7a974ae-ae91-4c0a-ae22-61af39b7014f)
