### PR TITLE
Refactor and Optimise Rational Cubic Interpolation Logic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,10 @@ jobs:
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: lcov.info
-        fail_ci_if_error: true
+# TODO: Dont work @hayden4r4
+#    - name: Upload coverage to Codecov
+#      uses: codecov/codecov-action@v3
+#      with:
+#        token: ${{ secrets.CODECOV_TOKEN }}
+#        files: lcov.info
+#        fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_approx_eq"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +70,7 @@ name = "blackscholes"
 version = "0.24.0"
 dependencies = [
  "approx",
+ "assert_approx_eq",
  "criterion",
  "log",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["finance", "option", "pricing", "blackscholes", "option-pricing"]
 criterion = "0.5.1"
 proptest = "1.5.0"
 approx = "0.5.1"
+assert_approx_eq = "1.1.0"
 
 [dependencies]
 num-traits = "0.2.19"
@@ -29,3 +30,8 @@ harness = false
 [[bench]]
 name = "implied_volatility"
 harness = false
+
+# enable this to run additional benches
+# [[bench]]
+# name = "additional_benches_to_verify"
+# harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ authors = ["Hayden Rose"]
 keywords = ["finance", "option", "pricing", "blackscholes", "option-pricing"]
 
 [dev-dependencies]
-criterion = "0.5.1"
-proptest = "1.5.0"
 approx = "0.5.1"
 assert_approx_eq = "1.1.0"
+criterion = "0.5.1"
+proptest = "1.5.0"
 
 [dependencies]
-num-traits = "0.2.19"
-statrs = "0.17.1"
 log = "0.4.22"
+num-traits = "0.2.19"
 once_cell = "1.19.0"
+statrs = "0.17.1"
 
 # Benchmarks
 [[bench]]

--- a/benches/additional_benches_to_verify.rs
+++ b/benches/additional_benches_to_verify.rs
@@ -1,0 +1,30 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn abs_vs_equality_benchmarks(c: &mut Criterion) {
+    let test_cases = vec![
+        (1.0f64, 1.0f64),                // Identical values
+        (1.0f64, 1.0f64 + f64::EPSILON), // Nearly identical values
+        (1.0f64, 2.0f64),                // Significantly different values
+    ];
+
+    for (i, (x, y)) in test_cases.iter().enumerate() {
+        let bench_name = format!("abs <= 0: case {}", i);
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                let result = black_box(*x).abs() <= 0.0;
+                black_box(result);
+            });
+        });
+
+        let bench_name = format!("equality: case {}", i);
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                let result = black_box(*x) == black_box(*y);
+                black_box(result);
+            });
+        });
+    }
+}
+
+criterion_group!(benches, abs_vs_equality_benchmarks);
+criterion_main!(benches);

--- a/src/lets_be_rational/rational_cubic.rs
+++ b/src/lets_be_rational/rational_cubic.rs
@@ -19,13 +19,12 @@ pub fn rational_cubic_interpolation(
 
     let h = x_r - x_l;
     // NOTE: This is an optimization as reuse calculated value of `h`.
+    // Based on `additional_benches_to_verify::abs_vs_equality_benchmarks` as an evidence
     if h.abs() <= f64::EPSILON {
         return Ok(0.5 * (y_l + y_r));
     }
 
-    // NOTE: Division optimization by multiplying with the reciprocal.
-    let inv_h = 1.0 / h;
-    let t = (x - x_l) * inv_h;
+    let t = (x - x_l) / h;
     let omt = 1.0 - t;
 
     // r should be greater than -1.
@@ -65,100 +64,83 @@ fn minimum_rational_cubic_control_parameter(
     let d_r_m_d_l = d_r - d_l;
     let d_r_m_s = d_r - s;
     let s_m_d_l = s - d_l;
-    let mut r1 = f64::NEG_INFINITY;
-    let mut r2 = r1;
 
-    // If monotonicity on this interval is possible, set r1 to satisfy the monotonicity condition (3.8).
-    if monotonic {
-        if !s.is_zero() {
-            r1 = (d_r + d_l) / s;
-        } else if prefer_shape_preservation_over_smoothness {
-            r1 = MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE;
-        }
-    }
-    if convex || concave {
-        if !s_m_d_l.is_zero() && !d_r_m_s.is_zero() {
-            r2 = f64::max((d_r_m_d_l / d_r_m_s).abs(), (d_r_m_d_l / s_m_d_l).abs());
-        } else if prefer_shape_preservation_over_smoothness {
-            r2 = MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE;
-        }
+    // If monotonicity on this interval is possible,
+    // set r1 to satisfy the monotonicity condition (3.8).
+    let r1 = if monotonic && !s.is_zero() {
+        (d_r + d_l) / s
     } else if monotonic && prefer_shape_preservation_over_smoothness {
-        r2 = MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE;
-    }
+        MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
+    } else {
+        f64::MIN
+    };
+
+    let r2 = match (convex || concave, monotonic, prefer_shape_preservation_over_smoothness) {
+        (true, _, _) if !s_m_d_l.is_zero() && !d_r_m_s.is_zero() =>
+            f64::max((d_r_m_d_l / d_r_m_s).abs(), (d_r_m_d_l / s_m_d_l).abs()),
+        (_, true, true) => MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+        _ => f64::MIN,
+    };
+
     f64::max(
         MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
         f64::max(r1, r2),
     )
 }
 
-fn rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
+pub enum Side {
+    Left,
+    Right,
+}
+
+fn rational_cubic_control_parameter(
     x_l: f64,
     x_r: f64,
     y_l: f64,
     y_r: f64,
     d_l: f64,
     d_r: f64,
-    second_derivative_l: f64,
+    second_derivative: f64,
+    side: Side,
 ) -> f64 {
     let h = x_r - x_l;
-    let numerator = 0.5 * h * second_derivative_l + (d_r - d_l);
+    let numerator = 0.5 * h * second_derivative + (d_r - d_l);
     if numerator.is_zero() {
         return 0.0;
     }
-    let denominator = (y_r - y_l) / h - d_l;
-    if denominator.is_zero() {
-        return if numerator > 0.0 {
-            MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
-        } else {
-            MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
-        };
+
+    let denominator = match side {
+        Side::Left => (y_r - y_l) / h - d_l,
+        Side::Right => d_r - (y_r - y_l) / h,
+    };
+
+    match (denominator.is_zero(), numerator > 0.0) {
+        (true, true) => MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+        (true, false) => MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+        _ => numerator / denominator,
     }
-    numerator / denominator
 }
 
-fn rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
+pub fn convex_rational_cubic_control_parameter(
     x_l: f64,
     x_r: f64,
     y_l: f64,
     y_r: f64,
     d_l: f64,
     d_r: f64,
-    second_derivative_r: f64,
-) -> f64 {
-    let h = x_r - x_l;
-    let numerator = 0.5 * h * second_derivative_r + (d_r - d_l);
-    if numerator.is_zero() {
-        return 0.0;
-    }
-    let denominator = d_r - (y_r - y_l) / h;
-    if denominator.is_zero() {
-        return if numerator > 0.0 {
-            MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
-        } else {
-            MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
-        };
-    }
-    numerator / denominator
-}
-
-pub fn convex_rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
-    x_l: f64,
-    x_r: f64,
-    y_l: f64,
-    y_r: f64,
-    d_l: f64,
-    d_r: f64,
-    second_derivative_l: f64,
+    second_derivative: f64,
     prefer_shape_preservation_over_smoothness: bool,
+    side: Side,
 ) -> f64 {
-    let r = rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
+    let r = rational_cubic_control_parameter(
         x_l,
         x_r,
         y_l,
         y_r,
         d_l,
         d_r,
-        second_derivative_l,
+        second_derivative,
+        side,
     );
     let r_min = minimum_rational_cubic_control_parameter(
         d_l,
@@ -166,34 +148,7 @@ pub fn convex_rational_cubic_control_parameter_to_fit_second_derivative_at_left_
         (y_r - y_l) / (x_r - x_l),
         prefer_shape_preservation_over_smoothness,
     );
-    r.max(r_min)
-}
 
-pub fn convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
-    x_l: f64,
-    x_r: f64,
-    y_l: f64,
-    y_r: f64,
-    d_l: f64,
-    d_r: f64,
-    second_derivative_r: f64,
-    prefer_shape_preservation_over_smoothness: bool,
-) -> f64 {
-    let r = rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
-        x_l,
-        x_r,
-        y_l,
-        y_r,
-        d_l,
-        d_r,
-        second_derivative_r,
-    );
-    let r_min = minimum_rational_cubic_control_parameter(
-        d_l,
-        d_r,
-        (y_r - y_l) / (x_r - x_l),
-        prefer_shape_preservation_over_smoothness,
-    );
     r.max(r_min)
 }
 
@@ -201,6 +156,8 @@ pub fn convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right
 mod tests {
     use super::*;
     use assert_approx_eq::assert_approx_eq;
+
+    const EPSILON: f64 = 1e-10;
 
     #[test]
     fn test_equal_x_values() {
@@ -259,5 +216,65 @@ mod tests {
     fn test_infinity_handling() {
         let result = rational_cubic_interpolation(f64::INFINITY, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_monotonic_increasing() {
+        let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 1.5, false);
+        assert_approx_eq!(result, 2.0, EPSILON);
+    }
+
+    #[test]
+    fn test_monotonic_decreasing() {
+        let result = minimum_rational_cubic_control_parameter(-2.0, -1.0, -1.5, false);
+        assert_approx_eq!(result, 2.0, EPSILON);
+    }
+
+    #[test]
+    fn test_convex() {
+        let result = minimum_rational_cubic_control_parameter(1.0, 3.0, 2.0, false);
+        assert_approx_eq!(result, 2.0, EPSILON);
+    }
+
+    #[test]
+    fn test_concave() {
+        let result = minimum_rational_cubic_control_parameter(3.0, 1.0, 2.0, false);
+        assert_approx_eq!(result, 2.0, EPSILON);
+    }
+
+    #[test]
+    fn test_non_monotonic_non_convex_non_concave() {
+        let result = minimum_rational_cubic_control_parameter(1.0, -1.0, 2.0, false);
+        assert_approx_eq!(result, MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+    }
+
+    #[test]
+    fn test_prefer_shape_preservation_monotonic() {
+        let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 0.0, true);
+        assert_approx_eq!(result, MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+    }
+
+    #[test]
+    fn test_prefer_shape_preservation_convex() {
+        let result = minimum_rational_cubic_control_parameter(1.0, 3.0, 2.0, true);
+        assert_approx_eq!(result, 2.0, EPSILON);
+    }
+
+    #[test]
+    fn test_zero_s_max() {
+        let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 0.0, true);
+        assert_approx_eq!(result, MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+    }
+
+    #[test]
+    fn test_zero_s_min() {
+        let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 0.0, false);
+        assert_approx_eq!(result, MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+    }
+
+    #[test]
+    fn test_equal_d_l_and_d_r() {
+        let result = minimum_rational_cubic_control_parameter(2.0, 2.0, 2.0, false);
+        assert_approx_eq!(result, 2.0, EPSILON);
     }
 }

--- a/src/lets_be_rational/rational_cubic.rs
+++ b/src/lets_be_rational/rational_cubic.rs
@@ -13,6 +13,8 @@ pub fn rational_cubic_interpolation(
     d_r: f64,
     r: f64,
 ) -> Result<f64, String> {
+    // TODO: verify is it necessary to check for infinite values
+    // or ensure that they are not present in the input
     if x.is_infinite() || x_l.is_infinite() || x_r.is_infinite() {
         return Err("Infinite value found in input".to_string());
     }
@@ -109,7 +111,7 @@ fn rational_cubic_control_parameter(
     side: Side,
 ) -> f64 {
     let h = x_r - x_l;
-    let numerator = 0.5 * h * second_derivative + (d_r - d_l);
+    let numerator = 0.5 * second_derivative.mul_add(h, d_r - d_l);
     if numerator.is_zero() {
         return 0.0;
     }
@@ -119,7 +121,10 @@ fn rational_cubic_control_parameter(
         Side::Right => d_r - (y_r - y_l) / h,
     };
 
-    match (denominator.is_zero(), numerator > 0.0) {
+    match (
+        denominator.is_zero() || denominator.is_infinite(),
+        numerator > 0.0,
+    ) {
         (true, true) => MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
         (true, false) => MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
         _ => numerator / denominator,

--- a/src/lets_be_rational/rational_cubic.rs
+++ b/src/lets_be_rational/rational_cubic.rs
@@ -67,12 +67,12 @@ fn minimum_rational_cubic_control_parameter(
 
     // If monotonicity on this interval is possible,
     // set r1 to satisfy the monotonicity condition (3.8).
-    let r1 = if monotonic && !s.is_zero() {
-        (d_r + d_l) / s
-    } else if monotonic && prefer_shape_preservation_over_smoothness {
-        MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
-    } else {
-        f64::MIN
+    let r1 = match (monotonic, s.is_zero()) {
+        (true, false) => (d_r + d_l) / s,
+        (true, true) if prefer_shape_preservation_over_smoothness => {
+            MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE
+        }
+        _ => f64::MIN,
     };
 
     let r2 = match (

--- a/src/lets_be_rational/rational_cubic.rs
+++ b/src/lets_be_rational/rational_cubic.rs
@@ -162,20 +162,22 @@ mod tests {
 
     #[test]
     fn test_equal_x_values() {
-        let result = rational_cubic_interpolation(1.0, 1.0, 1.0, 2.0, 3.0, 0.5, 0.5, 0.0).unwrap();
+        let result = rational_cubic_interpolation(1.0, 1.0, 1.0, 2.0, 3.0, 0.5, 0.5, 0.0)
+            .expect("Test purpose");
         assert_approx_eq!(result, 2.5, 1e-6);
     }
 
     #[test]
     fn test_linear_interpolation() {
-        let result =
-            rational_cubic_interpolation(1.5, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, f64::MAX).unwrap();
+        let result = rational_cubic_interpolation(1.5, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, f64::MAX)
+            .expect("Test purpose");
         assert_approx_eq!(result, 1.5, 1e-6);
     }
 
     #[test]
     fn test_cubic_interpolation() {
-        let result = rational_cubic_interpolation(1.5, 1.0, 2.0, 1.0, 2.0, 0.0, 0.0, 0.0).unwrap();
+        let result = rational_cubic_interpolation(1.5, 1.0, 2.0, 1.0, 2.0, 0.0, 0.0, 0.0)
+            .expect("Test purpose");
         assert_approx_eq!(result, 1.5, 1e-6);
     }
 
@@ -191,25 +193,25 @@ mod tests {
             1.0,
             MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE - 1e-10,
         )
-        .unwrap();
+        .expect("Test purpose");
         assert!(result.is_finite());
     }
 
     #[test]
     fn test_boundary_conditions() {
-        let result_left =
-            rational_cubic_interpolation(1.0, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0).unwrap();
+        let result_left = rational_cubic_interpolation(1.0, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0)
+            .expect("Test purpose");
         assert_approx_eq!(result_left, 1.0, 1e-6);
 
-        let result_right =
-            rational_cubic_interpolation(2.0, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0).unwrap();
+        let result_right = rational_cubic_interpolation(2.0, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0)
+            .expect("Test purpose");
         assert_approx_eq!(result_right, 2.0, 1e-6);
     }
 
     #[test]
     fn test_nan_propagation() {
-        let result =
-            rational_cubic_interpolation(f64::NAN, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0).unwrap();
+        let result = rational_cubic_interpolation(f64::NAN, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0)
+            .expect("Test purpose");
         assert!(result.is_nan());
     }
 

--- a/src/lets_be_rational/rational_cubic.rs
+++ b/src/lets_be_rational/rational_cubic.rs
@@ -12,27 +12,42 @@ pub fn rational_cubic_interpolation(
     d_l: f64,
     d_r: f64,
     r: f64,
-) -> f64 {
-    let h = x_r - x_l;
-    if h.abs() <= 0.0 {
-        return 0.5 * (y_l + y_r);
+) -> Result<f64, String> {
+    if x.is_infinite() || x_l.is_infinite() || x_r.is_infinite() {
+        return Err("Infinite value found in input".to_string());
     }
+
+    let h = x_r - x_l;
+    // NOTE: This is an optimization as reuse calculated value of `h`.
+    if h.abs() <= f64::EPSILON {
+        return Ok(0.5 * (y_l + y_r));
+    }
+
+    // NOTE: Division optimization by multiplying with the reciprocal.
+    let inv_h = 1.0 / h;
+    let t = (x - x_l) * inv_h;
+    let omt = 1.0 - t;
+
     // r should be greater than -1.
     // We do not use assert(r > -1) here in order to allow values such as NaN to be propagated as they should.
-    let t = (x - x_l) / h;
     if r < MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE {
-        let omt = 1.0 - t;
-        let t2 = t * t;
+        let t_power = t * t;
         let omt2 = omt * omt;
-        // Formula (2.4) divided by formula (2.5)
-        return (y_r * t2 * t
-            + (r * y_r - h * d_r) * t2 * omt
+
+        let numerator = y_r * t_power * t
+            + (r * y_r - h * d_r) * t_power * omt
             + (r * y_l + h * d_l) * t * omt2
-            + y_l * omt2 * omt)
-            / (1.0 + (r - 3.0) * t * omt);
+            + y_l * omt2 * omt;
+
+        let denominator = 1.0 + (r - 3.0) * t * omt;
+
+        // Formula (2.4) divided by formula (2.5)
+        Ok(numerator / denominator)
+    } else {
+        // Linear interpolation without over-or underflow.
+        // NOTE: `mul_add` is used to avoid the overhead of a separate multiplication and addition.
+        Ok(y_r.mul_add(t, y_l * omt))
     }
-    // Linear interpolation without over-or underflow.
-    y_r * t + y_l * (1.0 - t)
 }
 
 fn minimum_rational_cubic_control_parameter(
@@ -180,4 +195,69 @@ pub fn convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right
         prefer_shape_preservation_over_smoothness,
     );
     r.max(r_min)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+
+    #[test]
+    fn test_equal_x_values() {
+        let result = rational_cubic_interpolation(1.0, 1.0, 1.0, 2.0, 3.0, 0.5, 0.5, 0.0).unwrap();
+        assert_approx_eq!(result, 2.5, 1e-6);
+    }
+
+    #[test]
+    fn test_linear_interpolation() {
+        let result =
+            rational_cubic_interpolation(1.5, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, f64::MAX).unwrap();
+        assert_approx_eq!(result, 1.5, 1e-6);
+    }
+
+    #[test]
+    fn test_cubic_interpolation() {
+        let result = rational_cubic_interpolation(1.5, 1.0, 2.0, 1.0, 2.0, 0.0, 0.0, 0.0).unwrap();
+        assert_approx_eq!(result, 1.5, 1e-6);
+    }
+
+    #[test]
+    fn test_extreme_r_value() {
+        let result = rational_cubic_interpolation(
+            1.5,
+            1.0,
+            2.0,
+            1.0,
+            2.0,
+            1.0,
+            1.0,
+            MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE - 1e-10,
+        )
+        .unwrap();
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_boundary_conditions() {
+        let result_left =
+            rational_cubic_interpolation(1.0, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0).unwrap();
+        assert_approx_eq!(result_left, 1.0, 1e-6);
+
+        let result_right =
+            rational_cubic_interpolation(2.0, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0).unwrap();
+        assert_approx_eq!(result_right, 2.0, 1e-6);
+    }
+
+    #[test]
+    fn test_nan_propagation() {
+        let result =
+            rational_cubic_interpolation(f64::NAN, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0).unwrap();
+        assert!(result.is_nan());
+    }
+
+    #[test]
+    fn test_infinity_handling() {
+        let result = rational_cubic_interpolation(f64::INFINITY, 1.0, 2.0, 1.0, 2.0, 0.5, 0.5, 0.0);
+        assert!(result.is_err());
+    }
 }

--- a/src/lets_be_rational/rational_cubic.rs
+++ b/src/lets_be_rational/rational_cubic.rs
@@ -75,9 +75,14 @@ fn minimum_rational_cubic_control_parameter(
         f64::MIN
     };
 
-    let r2 = match (convex || concave, monotonic, prefer_shape_preservation_over_smoothness) {
-        (true, _, _) if !s_m_d_l.is_zero() && !d_r_m_s.is_zero() =>
-            f64::max((d_r_m_d_l / d_r_m_s).abs(), (d_r_m_d_l / s_m_d_l).abs()),
+    let r2 = match (
+        convex || concave,
+        monotonic,
+        prefer_shape_preservation_over_smoothness,
+    ) {
+        (true, _, _) if !s_m_d_l.is_zero() && !d_r_m_s.is_zero() => {
+            f64::max((d_r_m_d_l / d_r_m_s).abs(), (d_r_m_d_l / s_m_d_l).abs())
+        }
         (_, true, true) => MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
         _ => f64::MIN,
     };
@@ -132,16 +137,7 @@ pub fn convex_rational_cubic_control_parameter(
     prefer_shape_preservation_over_smoothness: bool,
     side: Side,
 ) -> f64 {
-    let r = rational_cubic_control_parameter(
-        x_l,
-        x_r,
-        y_l,
-        y_r,
-        d_l,
-        d_r,
-        second_derivative,
-        side,
-    );
+    let r = rational_cubic_control_parameter(x_l, x_r, y_l, y_r, d_l, d_r, second_derivative, side);
     let r_min = minimum_rational_cubic_control_parameter(
         d_l,
         d_r,
@@ -245,13 +241,21 @@ mod tests {
     #[test]
     fn test_non_monotonic_non_convex_non_concave() {
         let result = minimum_rational_cubic_control_parameter(1.0, -1.0, 2.0, false);
-        assert_approx_eq!(result, MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+        assert_approx_eq!(
+            result,
+            MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+            EPSILON
+        );
     }
 
     #[test]
     fn test_prefer_shape_preservation_monotonic() {
         let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 0.0, true);
-        assert_approx_eq!(result, MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+        assert_approx_eq!(
+            result,
+            MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+            EPSILON
+        );
     }
 
     #[test]
@@ -263,13 +267,21 @@ mod tests {
     #[test]
     fn test_zero_s_max() {
         let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 0.0, true);
-        assert_approx_eq!(result, MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+        assert_approx_eq!(
+            result,
+            MAXIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+            EPSILON
+        );
     }
 
     #[test]
     fn test_zero_s_min() {
         let result = minimum_rational_cubic_control_parameter(1.0, 2.0, 0.0, false);
-        assert_approx_eq!(result, MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE, EPSILON);
+        assert_approx_eq!(
+            result,
+            MINIMUM_RATIONAL_CUBIC_CONTROL_PARAMETER_VALUE,
+            EPSILON
+        );
     }
 
     #[test]

--- a/src/lets_be_rational/so_rational.rs
+++ b/src/lets_be_rational/so_rational.rs
@@ -206,6 +206,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     d2_f_lower_map_l_d_beta2,
                     true,
                 );
+            // TODO: Unwrap terrible approach, handle it properly
             f = rational_cubic_interpolation(
                 beta,
                 0.0,
@@ -215,7 +216,8 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                 1.0,
                 d_f_lower_map_l_d_beta,
                 r_ll,
-            );
+            )
+            .unwrap();
             if f <= 0.0 {
                 let t = beta / b_l;
                 f = (f_lower_map_l * t + b_l * (1.0 - t)) * t;
@@ -278,7 +280,9 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     0.0,
                     false,
                 );
-            s = rational_cubic_interpolation(beta, b_l, b_c, s_l, s_c, 1.0 / v_l, 1.0 / v_c, r_lm);
+            // TODO: Unwrap terrible approach, handle it properly
+            s = rational_cubic_interpolation(beta, b_l, b_c, s_l, s_c, 1.0 / v_l, 1.0 / v_c, r_lm)
+                .unwrap();
             s_left = s_l;
             s_right = s_c;
         }
@@ -302,7 +306,9 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     0.0,
                     false,
                 );
-            s = rational_cubic_interpolation(beta, b_c, b_h, s_c, s_h, 1.0 / v_c, 1.0 / v_h, r_hm);
+            // TODO: Unwrap terrible approach, handle it properly
+            s = rational_cubic_interpolation(beta, b_c, b_h, s_c, s_h, 1.0 / v_c, 1.0 / v_h, r_hm)
+                .unwrap();
             s_left = s_c;
             s_right = s_h;
         } else {
@@ -320,6 +326,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                         d2_f_upper_map_h_d_beta2,
                         true,
                     );
+                // TODO: Unwrap terrible approach, handle it properly
                 f = rational_cubic_interpolation(
                     beta,
                     b_h,
@@ -329,7 +336,8 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     d_f_upper_map_h_d_beta,
                     -0.5,
                     r_hh,
-                );
+                )
+                .unwrap();
             }
             if f <= 0.0 {
                 let h = b_max - b_h;

--- a/src/lets_be_rational/so_rational.rs
+++ b/src/lets_be_rational/so_rational.rs
@@ -3,7 +3,9 @@ use crate::lets_be_rational::intrinsic::normalised_intrinsic;
 use crate::lets_be_rational::normal_distribution::{
     inverse_f_upper_map, inverse_normal_cdf, standard_normal_cdf,
 };
-use crate::lets_be_rational::rational_cubic::{convex_rational_cubic_control_parameter, rational_cubic_interpolation, Side};
+use crate::lets_be_rational::rational_cubic::{
+    convex_rational_cubic_control_parameter, rational_cubic_interpolation, Side,
+};
 use crate::lets_be_rational::{DENORMALISATION_CUTOFF, ONE_OVER_SQRT_TWO_PI};
 use crate::OptionType;
 
@@ -191,18 +193,17 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
         if beta < b_l {
             let (f_lower_map_l, d_f_lower_map_l_d_beta, d2_f_lower_map_l_d_beta2) =
                 compute_f_lower_map_and_first_two_derivatives(x, s_l);
-            let r_ll =
-                convex_rational_cubic_control_parameter(
-                    0.0,
-                    b_l,
-                    0.0,
-                    f_lower_map_l,
-                    1.0,
-                    d_f_lower_map_l_d_beta,
-                    d2_f_lower_map_l_d_beta2,
-                    true,
-                    Side::Right,
-                );
+            let r_ll = convex_rational_cubic_control_parameter(
+                0.0,
+                b_l,
+                0.0,
+                f_lower_map_l,
+                1.0,
+                d_f_lower_map_l_d_beta,
+                d2_f_lower_map_l_d_beta2,
+                true,
+                Side::Right,
+            );
             // TODO: Unwrap terrible approach, handle it properly
             f = rational_cubic_interpolation(
                 beta,
@@ -266,18 +267,17 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
             return s;
         } else {
             let v_l = normalised_vega(x, s_l);
-            let r_lm =
-                convex_rational_cubic_control_parameter(
-                    b_l,
-                    b_c,
-                    s_l,
-                    s_c,
-                    1.0 / v_l,
-                    1.0 / v_c,
-                    0.0,
-                    false,
-                    Side::Right,
-                );
+            let r_lm = convex_rational_cubic_control_parameter(
+                b_l,
+                b_c,
+                s_l,
+                s_c,
+                1.0 / v_l,
+                1.0 / v_c,
+                0.0,
+                false,
+                Side::Right,
+            );
             // TODO: Unwrap terrible approach, handle it properly
             s = rational_cubic_interpolation(beta, b_l, b_c, s_l, s_c, 1.0 / v_l, 1.0 / v_c, r_lm)
                 .unwrap();
@@ -293,18 +293,17 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
         let b_h = normalised_black_call(x, s_h);
         if beta <= b_h {
             let v_h = normalised_vega(x, s_h);
-            let r_hm =
-                convex_rational_cubic_control_parameter(
-                    b_c,
-                    b_h,
-                    s_c,
-                    s_h,
-                    1.0 / v_c,
-                    1.0 / v_h,
-                    0.0,
-                    false,
-                    Side::Left,
-                );
+            let r_hm = convex_rational_cubic_control_parameter(
+                b_c,
+                b_h,
+                s_c,
+                s_h,
+                1.0 / v_c,
+                1.0 / v_h,
+                0.0,
+                false,
+                Side::Left,
+            );
             // TODO: Unwrap terrible approach, handle it properly
             s = rational_cubic_interpolation(beta, b_c, b_h, s_c, s_h, 1.0 / v_c, 1.0 / v_h, r_hm)
                 .unwrap();
@@ -314,18 +313,17 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
             let (f_upper_map_h, d_f_upper_map_h_d_beta, d2_f_upper_map_h_d_beta2) =
                 compute_f_upper_map_and_first_two_derivatives(x, s_h);
             if d2_f_upper_map_h_d_beta2 > -SQRT_DBL_MAX && d2_f_upper_map_h_d_beta2 < SQRT_DBL_MAX {
-                let r_hh =
-                    convex_rational_cubic_control_parameter(
-                        b_h,
-                        b_max,
-                        f_upper_map_h,
-                        0.0,
-                        d_f_upper_map_h_d_beta,
-                        -0.5,
-                        d2_f_upper_map_h_d_beta2,
-                        true,
-                        Side::Left,
-                    );
+                let r_hh = convex_rational_cubic_control_parameter(
+                    b_h,
+                    b_max,
+                    f_upper_map_h,
+                    0.0,
+                    d_f_upper_map_h_d_beta,
+                    -0.5,
+                    d2_f_upper_map_h_d_beta2,
+                    true,
+                    Side::Left,
+                );
                 // TODO: Unwrap terrible approach, handle it properly
                 f = rational_cubic_interpolation(
                     beta,

--- a/src/lets_be_rational/so_rational.rs
+++ b/src/lets_be_rational/so_rational.rs
@@ -204,7 +204,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                 true,
                 Side::Right,
             );
-            // TODO: Unwrap terrible approach, handle it properly
+            // TODO: Expect terrible approach, handle it properly
             f = rational_cubic_interpolation(
                 beta,
                 0.0,
@@ -215,7 +215,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                 d_f_lower_map_l_d_beta,
                 r_ll,
             )
-            .unwrap();
+            .expect("We should expect correct parameters");
             if f <= 0.0 {
                 let t = beta / b_l;
                 f = (f_lower_map_l * t + b_l * (1.0 - t)) * t;
@@ -278,9 +278,9 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                 false,
                 Side::Right,
             );
-            // TODO: Unwrap terrible approach, handle it properly
+            // TODO: Expect terrible approach, handle it properly
             s = rational_cubic_interpolation(beta, b_l, b_c, s_l, s_c, 1.0 / v_l, 1.0 / v_c, r_lm)
-                .unwrap();
+                .expect("We should expect correct parameters");
             s_left = s_l;
             s_right = s_c;
         }
@@ -304,9 +304,9 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                 false,
                 Side::Left,
             );
-            // TODO: Unwrap terrible approach, handle it properly
+            // TODO: Expect terrible approach, handle it properly
             s = rational_cubic_interpolation(beta, b_c, b_h, s_c, s_h, 1.0 / v_c, 1.0 / v_h, r_hm)
-                .unwrap();
+                .expect("We should expect correct parameters");
             s_left = s_c;
             s_right = s_h;
         } else {
@@ -324,7 +324,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     true,
                     Side::Left,
                 );
-                // TODO: Unwrap terrible approach, handle it properly
+                // TODO: Expect terrible approach, handle it properly
                 f = rational_cubic_interpolation(
                     beta,
                     b_h,
@@ -335,7 +335,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     -0.5,
                     r_hh,
                 )
-                .unwrap();
+                .expect("We should expect correct parameters");
             }
             if f <= 0.0 {
                 let h = b_max - b_h;

--- a/src/lets_be_rational/so_rational.rs
+++ b/src/lets_be_rational/so_rational.rs
@@ -3,11 +3,7 @@ use crate::lets_be_rational::intrinsic::normalised_intrinsic;
 use crate::lets_be_rational::normal_distribution::{
     inverse_f_upper_map, inverse_normal_cdf, standard_normal_cdf,
 };
-use crate::lets_be_rational::rational_cubic::{
-    convex_rational_cubic_control_parameter_to_fit_second_derivative_at_left_side,
-    convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right_side,
-    rational_cubic_interpolation,
-};
+use crate::lets_be_rational::rational_cubic::{convex_rational_cubic_control_parameter, rational_cubic_interpolation, Side};
 use crate::lets_be_rational::{DENORMALISATION_CUTOFF, ONE_OVER_SQRT_TWO_PI};
 use crate::OptionType;
 
@@ -196,7 +192,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
             let (f_lower_map_l, d_f_lower_map_l_d_beta, d2_f_lower_map_l_d_beta2) =
                 compute_f_lower_map_and_first_two_derivatives(x, s_l);
             let r_ll =
-                convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
+                convex_rational_cubic_control_parameter(
                     0.0,
                     b_l,
                     0.0,
@@ -205,6 +201,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     d_f_lower_map_l_d_beta,
                     d2_f_lower_map_l_d_beta2,
                     true,
+                    Side::Right,
                 );
             // TODO: Unwrap terrible approach, handle it properly
             f = rational_cubic_interpolation(
@@ -270,7 +267,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
         } else {
             let v_l = normalised_vega(x, s_l);
             let r_lm =
-                convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
+                convex_rational_cubic_control_parameter(
                     b_l,
                     b_c,
                     s_l,
@@ -279,6 +276,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     1.0 / v_c,
                     0.0,
                     false,
+                    Side::Right,
                 );
             // TODO: Unwrap terrible approach, handle it properly
             s = rational_cubic_interpolation(beta, b_l, b_c, s_l, s_c, 1.0 / v_l, 1.0 / v_c, r_lm)
@@ -296,7 +294,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
         if beta <= b_h {
             let v_h = normalised_vega(x, s_h);
             let r_hm =
-                convex_rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
+                convex_rational_cubic_control_parameter(
                     b_c,
                     b_h,
                     s_c,
@@ -305,6 +303,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                     1.0 / v_h,
                     0.0,
                     false,
+                    Side::Left,
                 );
             // TODO: Unwrap terrible approach, handle it properly
             s = rational_cubic_interpolation(beta, b_c, b_h, s_c, s_h, 1.0 / v_c, 1.0 / v_h, r_hm)
@@ -316,7 +315,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                 compute_f_upper_map_and_first_two_derivatives(x, s_h);
             if d2_f_upper_map_h_d_beta2 > -SQRT_DBL_MAX && d2_f_upper_map_h_d_beta2 < SQRT_DBL_MAX {
                 let r_hh =
-                    convex_rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
+                    convex_rational_cubic_control_parameter(
                         b_h,
                         b_max,
                         f_upper_map_h,
@@ -325,6 +324,7 @@ pub(crate) fn unchecked_normalised_implied_volatility_from_a_transformed_rationa
                         -0.5,
                         d2_f_upper_map_h_d_beta2,
                         true,
+                        Side::Left,
                     );
                 // TODO: Unwrap terrible approach, handle it properly
                 f = rational_cubic_interpolation(


### PR DESCRIPTION
This PR introduces a refactor and potential optimisation of the rational cubic interpolation logic in the lets_be_rational module. Key changes include:
- division optimisation
- code simplification
- improved rust readability
- tests test n ... tests
- function consolidation