### PR TITLE
Use correct constants

### DIFF
--- a/src/lets_be_rational/black.rs
+++ b/src/lets_be_rational/black.rs
@@ -63,9 +63,7 @@ fn normalised_black_call_with_optimal_use_of_codys_functions(x: f64, s: f64) -> 
 /// * `Some(f64)` containing the computed value if t < 0.21
 /// * `None` if t >= 0.21, indicating the approximation is not valid
 pub fn small_t_expansion_of_normalised_black_call(h: f64, t: f64) -> Option<f64> {
-    const T_THRESHOLD: f64 = 0.21;
-
-    if t >= T_THRESHOLD {
+    if t >= SMALL_T_EXPANSION_OF_NORMALISED_BLACK_THRESHOLD {
         return None;
     }
 
@@ -192,11 +190,11 @@ pub(crate) fn normalised_black(x: f64, s: f64, option_type: OptionType) -> f64 {
 /// * `Ok(f64)` - The computed price
 /// * `Err(String)` - An error message if the input is out of the valid range
 pub fn asymptotic_expansion_of_normalised_black_call(h: f64, t: f64) -> Result<f64, &'static str> {
-    let tau_small: f64 = 2.0 * f64::EPSILON.sqrt().powi(16);
-
     // Check if we're in the correct region
     // From section 6: "In the region of large negative h, we can realize these preferences by the aid of the formulation (6.10) for the normalized Black function"
-    if h > H_LARGE || t >= (h.abs() - H_LARGE.abs() + tau_small) {
+    if h > H_LARGE
+        || t >= (h.abs() - H_LARGE.abs() + SMALL_T_EXPANSION_OF_NORMALISED_BLACK_THRESHOLD)
+    {
         return Err("This asymptotic expansion is only valid for large negative h and small t");
     }
 

--- a/src/lets_be_rational/black.rs
+++ b/src/lets_be_rational/black.rs
@@ -60,8 +60,8 @@ fn normalised_black_call_with_optimal_use_of_codys_functions(x: f64, s: f64) -> 
 ///
 /// # Returns
 ///
-/// * `Some(f64)` containing the computed value if t < 0.21
-/// * `None` if t >= 0.21, indicating the approximation is not valid
+/// * `Some(f64)` containing the computed value if t < 0.21132486540518713
+/// * `None` otherwise, indicating the approximation is not valid
 pub fn small_t_expansion_of_normalised_black_call(h: f64, t: f64) -> Option<f64> {
     if t >= SMALL_T_EXPANSION_OF_NORMALISED_BLACK_THRESHOLD {
         return None;

--- a/tests/test_pricing.rs
+++ b/tests/test_pricing.rs
@@ -42,6 +42,17 @@ const INPUTS_PUT_ITM: Inputs = Inputs {
     sigma: Some(0.2),
 };
 
+const INPUTS_BRANCH_CUT: Inputs = Inputs {
+    option_type: OptionType::Put,
+    s: 100.0,
+    k: 100.0,
+    p: None,
+    r: 0.0,
+    q: 0.0,
+    sigma: Some(0.421),
+    t: 1.0,
+};
+
 #[test]
 fn price_call_otm() {
     assert_approx_eq!(INPUTS_CALL_OTM.calc_price().unwrap(), 0.0376, 0.001);
@@ -90,16 +101,9 @@ fn price_using_lets_be_rational() {
 
 #[test]
 fn test_rational_price_near_branch_cut() {
-    Inputs {
-        option_type: OptionType::Put,
-        s: 1.0,
-        k: 1.0,
-        p: None,
-        r: 0.0,
-        q: 0.0,
-        sigma: Some(0.421),
-        t: 1.0,
-    }
-    .calc_rational_price()
-    .unwrap();
+    assert_approx_eq!(
+        INPUTS_BRANCH_CUT.calc_rational_price().unwrap(),
+        16.67224,
+        0.001
+    );
 }

--- a/tests/test_pricing.rs
+++ b/tests/test_pricing.rs
@@ -87,3 +87,19 @@ fn price_using_lets_be_rational() {
         0.001
     );
 }
+
+#[test]
+fn test_rational_price_near_branch_cut() {
+    Inputs {
+        option_type: OptionType::Put,
+        s: 1.0,
+        k: 1.0,
+        p: None,
+        r: 0.0,
+        q: 0.0,
+        sigma: Some(0.421),
+        t: 1.0,
+    }
+    .calc_rational_price()
+    .unwrap();
+}


### PR DESCRIPTION
I got an error because of a `t` value between `0.21` and `SMALL_T_EXPANSION_OF_NORMALISED_BLACK_THRESHOLD`, which resulted in `normalised_black_call` dispatching to `small_t_expansion_of_normalised_black_call` and then failing the expect.

This fixes that.